### PR TITLE
Added len() function to Ds3TapeList (PYTHONSDK-47)

### DIFF
--- a/ds3/ds3.py
+++ b/ds3/ds3.py
@@ -912,11 +912,17 @@ class Ds3TapeList(object):
 
     Members:
         tapes (List<Ds3Tape>) 
+
+        length (int) : Number of tapes returned. (Same as len())
     """
     def __init__(self, ds3Tapes):
         array = ds3Tapes.contents.tapes
         length = ds3Tapes.contents.num_tapes
         self.tapes = arrayToList(array, length, Ds3Tape)
+        self.length = length
+
+    def __len__(self):
+        return self.length 
         
 class Ds3Tape(object):
     """Descibes a Tape 


### PR DESCRIPTION
Fixes existing unit tests (and is a good idea). Old call returned a string array, new object should support len()