### PR TITLE
PYTHONSDK-80: Fixed parsing of string response payloads

### DIFF
--- a/ds3/ds3.py
+++ b/ds3/ds3.py
@@ -8941,7 +8941,7 @@ class GetJobToReplicateSpectraS3Response(AbstractResponse):
     def process_response(self, response):
         self.__check_status_codes__([200])
         if self.response.status == 200:
-            self.result = parseModel(xmldom.fromstring(response.read()), String())
+            self.result = response.read()
 
 
 class GetJobsSpectraS3Response(AbstractResponse):
@@ -9571,7 +9571,7 @@ class GetBlobPersistenceSpectraS3Response(AbstractResponse):
     def process_response(self, response):
         self.__check_status_codes__([200])
         if self.response.status == 200:
-            self.result = parseModel(xmldom.fromstring(response.read()), String())
+            self.result = response.read()
 
 
 class GetObjectDetailsSpectraS3Response(AbstractResponse):

--- a/tests/clientTests.py
+++ b/tests/clientTests.py
@@ -9,8 +9,6 @@
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
 #   specific language governing permissions and limitations under the License.
 
-import os
-import stat
 import sys
 import tempfile
 import unittest
@@ -19,7 +17,7 @@ from ds3.ds3 import *
 
 bucketName = "python_test_bucket"
 resources = ["beowulf.txt", "sherlock_holmes.txt", "tale_of_two_cities.txt", "ulysses.txt"]
-bigFile = "lesmis.txt";
+bigFile = "lesmis.txt"
 unicodeResources = [unicode(filename) for filename in resources]
 
 
@@ -1358,3 +1356,38 @@ class Ds3NetworkTestCase(Ds3TestCase):
         result = self.client.net_client.build_path("/test/path/" + obj_name)
 
         self.assertEqual(result, expected)
+
+
+class MockedHttpResponse:
+    def __init__(self, status, content="", headers=[]):
+        self.status = status
+        self.headers = headers
+        self.content = content
+
+    def getheaders(self):
+        return self.headers
+
+    def read(self):
+        return self.content
+
+
+class ResponseParsingTestCase(unittest.TestCase):
+    def testGetJobToReplicate(self):
+        content = "some content to test response parsing"
+
+        request = GetJobToReplicateSpectraS3Request("jobId")
+
+        mocked_response = MockedHttpResponse(200, content)
+
+        response = GetJobToReplicateSpectraS3Response(mocked_response, request)
+        self.assertEqual(response.result, content)
+
+    def testGetBlobPersistence(self):
+        content = "some content to test response parsing"
+
+        mocked_request = GetBlobPersistenceSpectraS3Request("request payload")
+
+        mocked_response = MockedHttpResponse(200, content)
+
+        response = GetBlobPersistenceSpectraS3Response(mocked_response, mocked_request)
+        self.assertEqual(response.result, content)


### PR DESCRIPTION
Fixed parsing of response payloads of type String which previously produced errors.

Added MockedHttpResponse for creating unit tests for response handlers that do not require a client.

All tests passing.